### PR TITLE
Update v1beta1 to v1. Ver. v1beta1 is deprecated.

### DIFF
--- a/webapp/candysorter/ext/google/cloud/ml/_http.py
+++ b/webapp/candysorter/ext/google/cloud/ml/_http.py
@@ -20,5 +20,5 @@ from google.cloud import _http
 
 class Connection(_http.JSONConnection):
     API_BASE_URL = 'https://ml.googleapis.com'
-    API_VERSION = 'v1beta1'
+    API_VERSION = 'v1'
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'


### PR DESCRIPTION
Update GCP ML API version from v1beta1 to v1. This is done since version v1beta1 is now deprecated.